### PR TITLE
Fixing hypatia export to join element fields by their codes

### DIFF
--- a/lib/hyacinth_export/values.rb
+++ b/lib/hyacinth_export/values.rb
@@ -2,7 +2,7 @@ require 'ostruct'
 
 module Values
   class << self; attr_accessor :id, :item_id, :element_id, :parent_id, :data; end
-  
+
   ID = 0
   ITEM_ID = 1
   ELEMENT_ID = 2
@@ -25,32 +25,22 @@ module Values
   end
 
   def self.accumulate(prefix,parent_id,elements_to_codes,item_values,value_map)
-   children_by_element = Hash.new {|hash,key| hash[key] = []}
-   item_values.each do |value|
-     next unless value.parent_id == parent_id
-     children_by_element[value.element_id] << value
+   children_by_code = Hash.new {|hash,key| hash[key] = []}
+   item_values.where(parent_id: parent_id).each do |value|
+    unless elements_to_codes[value.element_id]
+      elements_to_codes[value.element_id] = value.element.code
+    end
+    
+    code = elements_to_codes[value.element_id]
+    children_by_code[code] << value
    end
-   children_by_element.each do |element_id, element_values|
-     # load missing elements if possible
-     unless elements_to_codes.has_key? element_id.to_s
-      element = Element.find(element_id.to_i)
 
-      elements_to_codes[element.id.to_s] = element.code
-      elements = Element.find(*element.nested_children_ids)
-      elements = [elements] unless elements.respond_to? :each
-      elements.each do |element|
-        elements_to_codes[element.id.to_s] = element.code
-      end
-     end
-     code = elements_to_codes[element_id.to_s]
-     if code.nil?
-       puts "no code for #{element_id}"
-       next
-     end
+   children_by_code.each do |code, element_values|
      tag = prefix.nil? ? code : "#{prefix}:#{code}"
      if element_values.length > 1
        element_values.each_with_index do |element_value, ix|
-         ix_tag = parent_id ? "#{tag}-#{ix + 1}" : tag # don't index root element
+
+         ix_tag = (parent_id && !ix.zero?) ? "#{tag}-#{ix + 1}" : tag # don't index root element and don't add suffix if first element
          if element_value.data
            value_map[ix_tag] = element_value.data
          end

--- a/lib/tasks/hyacinth.rake
+++ b/lib/tasks/hyacinth.rake
@@ -43,7 +43,9 @@ namespace :hyacinth do
       puts "pass items=ID,ID,ID... or item_type=ID [limit=LIMIT]"
     end
 
-    HyacinthExport.export_values(items) if items
+    filename = File.join(Rails.root, 'tmp', 'data', "individual-item-export-from-hypatia.csv")
+    items = [items] unless items.respond_to? :each
+    HyacinthExport.export_values(items, filename) if items
   end
 
   desc 'export template from Hypatia'


### PR DESCRIPTION
When exporting ETDs author names were being overwritten because multiple elements had the same code.